### PR TITLE
added a new flow to support subscription purges

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,9 +21,3 @@ We recommend you post your name as a ##, then a quick blurb about you, then your
 * Derry, NH
 
 * [My Site](https://www.andrewesherman.net)
-
-## Liz Lefavour
-
-* Dog Lover, Customer Service Manager
-
-* Manchester, NH

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 This library is a small wrapper around a subset of the Chargify API.
 
-*Note: As of December 28th, 2020, this library is no longer actively maintained. New maintainers are welcome to email the Wagz engineering team to take lead over the library.*
+This library is actively used in production, however not all end points are used regularly. We do our best to keep up to date with changes, but focus primarily on our own
+needs. However, pull requests are always welcome!
 
 ## Usage
 
@@ -29,69 +30,76 @@ a solution is provided in the official REST API:
 
 A recent PR included a CLI. We will be moving it out into a separate repository. Do not rely on using it in this repo.
 
-## Other Libraries
+## Future Improvements
 
-We use the following additional tools in this library, and thank the maintainers and contributors of those libraries:
+The following are improvements we would like to make, or would like PRs to address (reach out to us first to make sure no one else has started working on it though!):
 
-* [testify](https://github.com/stretchr/testify) - Makes our unit tests more readable and management
+* [ ] Migrate all `makeCall` and `makeEventsCall` invocations to the new `makeAPICall` function. This includes modifying the INTERNAL allocation to the options struct.
+
+* [ ] Update calls to take options structs with pointers; add new functions where deprecation would occur so we can maintain backwards compatibility.
 
 ## Implemented Endpoints
 
+Note that Chargify changes their API doc URLs regularly, so we have stopped providing links directly to the end points.
+
 ### Customers
 
-* [Create Customer](https://reference.chargify.com/v1/customers/create-a-customer)
-* [Delete Customer](https://reference.chargify.com/v1/customers/delete-the-customer)
-* [Get Customers](https://reference.chargify.com/v1/customers/list-customers-for-a-site)
-* [Search for Customers](https://reference.chargify.com/v1/customers/search-for-customer)
+* Create Customer
+* Delete Customer
+* Get Customers
+* Search for Customers
 
 ### Events
 
-* [List Events](https://reference.chargify.com/v1/events/list-events)
-* [List Events for Subscription](https://reference.chargify.com/v1/events/list-events-for-subscription)
-* [Total Event Count](https://reference.chargify.com/v1/events/total-event-count)
-* [Event Ingestion](https://reference.chargify.com/v1/events-based-billing/%2Fevent-ingestion)  
-* [Bulk Event Ingestion](https://reference.chargify.com/v1/events-based-billing/bulk-event-ingestion)
+* List Events
+* List Events for Subscription
+* Total Event Count
+* Event Ingestion
+* Bulk Event Ingestion
 
 ### Payment Profiles
 
-* [Create Payment Profile](https://reference.chargify.com/v1/payment-profiles/create-a-payment-profile)
-* [Delete Payment Profile](https://reference.chargify.com/v1/payment-profiles/delete-payment-profile)
+* Create Payment Profile
+* Delete Payment Profile
 
 ### Product Families
 
-* [Create Product Family](https://reference.chargify.com/v1/product-families/create-a-product)
-* [Get Product Family](https://reference.chargify.com/v1/product-families/list-product-family-via-chargify-id)
-* [Read Component By ID](https://reference.chargify.com/v1/components/read-component-by-id)
-* [Read Component By Handle](https://reference.chargify.com/v1/components/read-component-by-handle)
-* [List Comonents for Product Family](https://reference.chargify.com/v1/components/list-components-for-product-family)
-* [List Product Familiy via Site](https://reference.chargify.com/v1/product-families/list-product-family-via-site)
+* Create Product Family
+* Get Product Family
+* Read Component By ID
+* Read Component By Handle
+* List Comonents for Product Family
+* List Product Familiy via Site
 
 ### Products
 
-* [Create a Product](https://reference.chargify.com/v1/products/create-a-product-1)
-* [Archive a Product](https://reference.chargify.com/v1/products/archive-a-product)
-* [Update a Product](https://reference.chargify.com/v1/products/update-a-product)
-* [Get a Product By ID](https://reference.chargify.com/v1/products/read-the-product-via-chargify-id)
-* [Get a Product By Handle](https://reference.chargify.com/v1/products/read-the-product-via-api-handle)
-* [Get a Product In Family](https://reference.chargify.com/v1/products/list-products)
+* Create a Product
+* Archive a Product
+* Update a Product
+* Get a Product By ID
+* Get a Product By Handle
+* Get a Product In Family
 
 ### Subscriptions
 
-* [Create Subscription](https://reference.chargify.com/v1/subscriptions/create-subscription)
-* [Update Subscription](https://reference.chargify.com/v1/subscriptions-product-changes-migrations-upgrades-downgrades)
-* [Cancel Subscription - Immediately](https://reference.chargify.com/v1/subscriptions-cancellations/cancel-subscription)
-* [Cancel Subscription - Delayed](https://reference.chargify.com/v1/subscriptions-cancellations/cancel-subscription-delayed-method-1)
-* [Remove Delayed Cancellation](https://reference.chargify.com/v1/subscriptions-cancellations/cancel-subscription-remove-delayed-method)
+* Create Subscription
+* Update Subscription
+* Cancel Subscription - Immediately
+* Cancel Subscription - Delayed
+* Remove Delayed Cancellation
+* List Subscriptions
+* Purge a Subscription (only works in test mode!)
 
 ### Coupons
 
-* [Create a Coupon](https://reference.chargify.com/v1/coupons/create-coupon)
-* [Find a Coupon](https://reference.chargify.com/v1/coupons/find-coupon)
-* [Archive a Coupon](https://reference.chargify.com/v1/coupons/archive-coupon)
+* Create a Coupon
+* Find a Coupon
+* Archive a Coupon
+* List Coupons
 
 ## Hiring
 
-Are you on the New Hampshire Seacoast and love Go, Typescript, Swift, or Java? Send an email to engineering@wagz.com and let's find out if we're a good match!
+Want to join an awesome team building cool products to improve the lives of pets and their owners? Send an email to engineering@wagz.com and let's find out if we're a good match! We are a remote-first company based in New Hampshire.
 
 ## Contributing
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -16,6 +16,7 @@ const (
 	endpointCouponCreate    = "coupon_create"
 	endpointCouponGetByCode = "find_coupon"
 	endpointCouponArchive   = "coupon_archive"
+	endpointCouponsList     = "coupons_list"
 
 	endpointCustomerCreate            = "customer_create"
 	endpointCustomerDelete            = "customer_delete"
@@ -56,6 +57,7 @@ const (
 	endpointSubscriptionCancelDelayed       = "subscription_cancel_delayed"
 	endpointSubscriptionRemoveDelayedCancel = "subscription_remove_delayed_cancel"
 	endpointSubscriptionPurge               = "subscription_purge"
+	endpointSubscriptionsList               = "subscriptions_list"
 
 	endpointSubscriptionMigrate   = "subscription_migrate"
 	endpointSubscriptionUpdateNow = "subscription_update_now"
@@ -360,6 +362,11 @@ var endpoints = map[string]endpoint{
 			"{subscriptionID}",
 		},
 	},
+	endpointSubscriptionsList: {
+		method:     http.MethodGet,
+		uri:        "subscriptions.json",
+		pathParams: []string{},
+	},
 
 	// invoices
 	endpointGetInvoices: {
@@ -401,5 +408,10 @@ var endpoints = map[string]endpoint{
 			"{familyID}",
 			"{couponID}",
 		},
+	},
+	endpointCouponsList: {
+		method:     http.MethodGet,
+		uri:        "coupons.json",
+		pathParams: []string{},
 	},
 }

--- a/endpoints.go
+++ b/endpoints.go
@@ -55,6 +55,7 @@ const (
 	endpointSubscriptionCancelImmediately   = "subscription_cancel_immediately"
 	endpointSubscriptionCancelDelayed       = "subscription_cancel_delayed"
 	endpointSubscriptionRemoveDelayedCancel = "subscription_remove_delayed_cancel"
+	endpointSubscriptionPurge               = "subscription_purge"
 
 	endpointSubscriptionMigrate   = "subscription_migrate"
 	endpointSubscriptionUpdateNow = "subscription_update_now"
@@ -350,6 +351,13 @@ var endpoints = map[string]endpoint{
 		pathParams: []string{
 			"{subscriptionID}",
 			"{componentID}",
+		},
+	},
+	endpointSubscriptionPurge: {
+		method: http.MethodPost,
+		uri:    "subscriptions/{subscriptionID}/purge.json",
+		pathParams: []string{
+			"{subscriptionID}",
 		},
 	},
 

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,55 @@
+package chargify
+
+// these helpers are designed to make query params a little more manageable
+// for inclsion and is modeled off of libraries such as Stripes. These each to have a FromX
+// and a ToX funcs
+
+// FromString converts a value to a pointer
+func FromString(input string) *string {
+	return &input
+}
+
+// ToString takes a pointer and gives the value
+func ToString(input *string) string {
+	return *input
+}
+
+// FromInt64 converts a value to a pointer
+func FromInt64(input int64) *int64 {
+	return &input
+}
+
+// ToInt64 takes a pointer and gives the value
+func ToInt64(input *int64) int64 {
+	return *input
+}
+
+// FromInt converts a value to a pointer
+func FromInt(input int) *int {
+	return &input
+}
+
+// ToInt takes a pointer and gives the value
+func ToInt(input *int) int {
+	return *input
+}
+
+// FromFloat64 converts a value to a pointer
+func FromFloat64(input float64) *float64 {
+	return &input
+}
+
+// ToFloat64 takes a pointer and gives the value
+func ToFloat64(input *float64) float64 {
+	return *input
+}
+
+// FromBool converts a value to a pointer
+func FromBool(input bool) *bool {
+	return &input
+}
+
+// ToBool takes a pointer and gives the value
+func ToBool(input *bool) bool {
+	return *input
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -26,7 +26,7 @@ func JSON(obj interface{}) string {
 	return string(jsonBytes)
 }
 
-// MergeStringToStringMap, last one wins on conflick
+// MergeStringToStringMap, last one wins on conflict
 func MergeStringToStringMap(ms ...map[string]string) map[string]string {
 	res := map[string]string{}
 	for _, m := range ms {

--- a/request.go
+++ b/request.go
@@ -25,6 +25,7 @@ type APIReturn struct {
 type makeCallOptions struct {
 	End              endpoint
 	Root             string
+	IsEvent          bool
 	PathParams       *map[string]string
 	MultiQueryParams *map[string][]string
 	QueryParams      *map[string]string
@@ -35,6 +36,14 @@ type makeCallOptions struct {
 func makeAPICall(options *makeCallOptions) (ret APIReturn, err error) {
 	if options == nil {
 		return APIReturn{}, errors.New("options must be specified")
+	}
+	// check if the root is blank; we allow overriding if they really want to
+	if options.Root == "" {
+		if options.IsEvent {
+			options.Root = config.eventsRoot
+		} else {
+			options.Root = config.root
+		}
 	}
 	return options.makeCallEx()
 }
@@ -62,6 +71,7 @@ func makeEventsCall(end endpoint, body interface{}, pathParams *map[string]strin
 	return options.makeCallEx()
 }
 
+// this is a helper if the options are set up and then called on the struct
 func (o *makeCallOptions) makeCallEx() (ret APIReturn, err error) {
 	return executeAPICall(o)
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -32,6 +32,8 @@ type Subscription struct {
 	ReceivesInvoiceEmails         bool      `json:"receives_invoice_emails" mapstructure:"receives_invoice_emails"`                             // (Optional) Default: True - Whether or not this subscription is set to receive emails related to this subscription.
 	Customer                      *Customer `json:"customer,omitempty" mapstructure:"customer"`
 	Product                       *Product  `json:"product,omitempty" mapstructure:"product"`
+	// some of these are only used on the return
+	State string `json:"state,omitempty" mapstructure:"state"` // the state of the subscription
 }
 type ListSubscriptionEventsQueryParams struct {
 	Page      *int    `json:"page,omitempty" mapstructure:"page,omitempty"`
@@ -40,6 +42,68 @@ type ListSubscriptionEventsQueryParams struct {
 	MaxID     *int    `json:"max_id,omitempty" mapstructure:"max_id,omitempty"`
 	Direction *string `json:"direction,omitempty" mapstructure:"direction,omitempty"`
 	Filter    *string `json:"filter,omitempty" mapstructure:"filter,omitempty"`
+}
+
+// ListSubscriptionsQueryParams are the query parameters for listing subscriptions; see:
+// https://developers.chargify.com/docs/api-docs/51c68dd4dcb2b-list-subscriptions
+type ListSubscriptionsQueryParams struct {
+	Coupon              *int64  `json:"coupon"`
+	DateField           *string `json:"date_field"`
+	Direction           *string `json:"direction"`
+	EndDate             *string `json:"end_date"`
+	EndDateTime         *string `json:"end_datetime"`
+	Page                *int    `json:"page"`
+	PerPage             *int    `json:"per_page"`
+	Product             *string `json:"product"`
+	ProductPricePointID *int64  `json:"product_price_point_id"`
+	Sort                *string `json:"sort"`
+	StartDate           *string `json:"start_date"`
+	StartDateTime       *string `json:"start_datetime"`
+	State               *string `json:"state"`
+}
+
+func (input *ListSubscriptionsQueryParams) toMap() *map[string]string {
+	m := map[string]string{}
+	if input.Coupon != nil {
+		m["coupon"] = fmt.Sprintf("%d", ToInt64(input.Coupon))
+	}
+	if input.DateField != nil {
+		m["date_field"] = ToString(input.DateField)
+	}
+	if input.Direction != nil {
+		m["direction"] = ToString(input.Direction)
+	}
+	if input.EndDate != nil {
+		m["end_date"] = ToString(input.EndDate)
+	}
+	if input.EndDateTime != nil {
+		m["end_datetime"] = ToString(input.EndDateTime)
+	}
+	if input.Page != nil {
+		m["page"] = fmt.Sprintf("%d", ToInt(input.Page))
+	}
+	if input.PerPage != nil {
+		m["per_page"] = fmt.Sprintf("%d", ToInt(input.PerPage))
+	}
+	if input.Product != nil {
+		m["product"] = ToString(input.Product)
+	}
+	if input.ProductPricePointID != nil {
+		m["product_price_point_id"] = fmt.Sprintf("%d", ToInt64(input.ProductPricePointID))
+	}
+	if input.Sort != nil {
+		m["sort"] = ToString(input.Sort)
+	}
+	if input.StartDate != nil {
+		m["start_date"] = ToString(input.StartDate)
+	}
+	if input.StartDateTime != nil {
+		m["start_datetime"] = ToString(input.StartDateTime)
+	}
+	if input.State != nil {
+		m["state"] = ToString(input.State)
+	}
+	return &m
 }
 
 // CreateSubscriptionForCustomer creates a new subscription. When creating a subscription, you must specify a product and a customer.
@@ -265,4 +329,45 @@ func PurgeSubscription(subscriptionID int64, customerID int64, cascadeCustomer b
 		return fmt.Errorf("received a %d", ret.HTTPCode)
 	}
 	return nil
+}
+
+// ListSubscriptions lists out the subscriptions based upon the result of the passed in query params
+func ListSubscriptions(params *ListSubscriptionsQueryParams) ([]Subscription, error) {
+	if params == nil {
+		params = &ListSubscriptionsQueryParams{}
+	}
+	queryParams := params.toMap()
+	options := &makeCallOptions{
+		End:         endpoints[endpointSubscriptionsList],
+		QueryParams: queryParams,
+	}
+
+	data := []Subscription{}
+
+	ret, err := makeAPICall(options)
+	if err != nil {
+		return data, err
+	}
+	apiBody, bodyOK := ret.Body.([]interface{})
+	if !bodyOK {
+		return nil, errors.New("could not understand server response")
+	}
+	// the result is an array of objects that have a subscription key, similar to:
+	// 	[
+	//   {
+	//     "subscription": {...}
+	//   }
+	// ]
+	// so we have a [] of interfaces; loop and convert
+	for i := range apiBody {
+		if raw, rawOK := apiBody[i].(map[string]interface{}); rawOK {
+			sub := Subscription{}
+			err = mapstructure.Decode(raw["subscription"], &sub)
+			if err == nil {
+				data = append(data, sub)
+			}
+		}
+
+	}
+	return data, nil
 }


### PR DESCRIPTION
Added a new way of making API calls against Chargify to support arrays in the query params and make the internal calls more flexible. Should be transparent to consumers. Note that this does not include the full implementation and refactor of the calls to the newer flows, so both are still supported for the time being.